### PR TITLE
Dockerfile improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ RUN echo "source /opt/ros/noetic/setup.bash\n" \
 
 
 # build deps
-RUN /bin/bash -lc "cd amrl_msgs && make -j"
-RUN /bin/bash -lc "cd ut_automata && make -j"
+RUN /bin/bash -lc "cd amrl_msgs && make"
+RUN /bin/bash -lc "cd ut_automata && make"
 
 # add launcher
 ENV CS378_DOCKER_CONTEXT 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ros:noetic
+FROM registry.hub.docker.com/library/ros:noetic
 
 # install apt deps
 RUN apt-get update && \
@@ -22,13 +22,12 @@ RUN git clone https://github.com/ut-amrl/amrl_maps.git && \
     git clone https://github.com/ut-amrl/ut_automata.git --recurse-submodules
 
 # set up .bashrc
-SHELL ["/bin/bash", "-l", "-c"]
-RUN echo -e "source /opt/ros/noetic/setup.bash\n" \
+RUN echo "source /opt/ros/noetic/setup.bash\n" \
 "export ROS_PACKAGE_PATH=\$ROS_PACKAGE_PATH:~/ut_automata\n" \
 "export ROS_PACKAGE_PATH=\$ROS_PACKAGE_PATH:~/cs378_starter\n" \
 "export ROS_PACKAGE_PATH=\$ROS_PACKAGE_PATH:~/amrl_maps\n" \
 "export ROS_PACKAGE_PATH=\$ROS_PACKAGE_PATH:~/amrl_msgs" >> ~/.profile
-RUN echo -e "source /opt/ros/noetic/setup.bash\n" \
+RUN echo "source /opt/ros/noetic/setup.bash\n" \
 "export ROS_PACKAGE_PATH=\$ROS_PACKAGE_PATH:~/ut_automata\n" \
 "export ROS_PACKAGE_PATH=\$ROS_PACKAGE_PATH:~/cs378_starter\n" \
 "export ROS_PACKAGE_PATH=\$ROS_PACKAGE_PATH:~/amrl_maps\n" \
@@ -36,8 +35,8 @@ RUN echo -e "source /opt/ros/noetic/setup.bash\n" \
 
 
 # build deps
-RUN source ~/.profile && cd amrl_msgs && make -j
-RUN source ~/.profile && cd ut_automata && make 
+RUN /bin/bash -lc "cd amrl_msgs && make -j"
+RUN /bin/bash -lc "cd ut_automata && make -j"
 
 # add launcher
 ENV CS378_DOCKER_CONTEXT 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN source ~/.profile && cd amrl_msgs && make -j
 RUN source ~/.profile && cd ut_automata && make 
 
 # add launcher
+ENV CS378_DOCKER_CONTEXT 1
 COPY --chown=dev:dev ./tmux_session.sh /home/dev/tmux_session.sh
 RUN chmod u+x /home/dev/tmux_session.sh
 CMD [ "/home/dev/tmux_session.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ RUN apt-get update && \
     apt-get install -y git libgflags-dev libpopt-dev \
                        libgoogle-glog-dev liblua5.1-0-dev \
                        libboost-all-dev libqt5websockets5-dev \
-                       python-is-python3 libeigen3-dev sudo
+                       python-is-python3 libeigen3-dev sudo 
+
+# multiplexers to run roscore and other infra in background
+RUN apt-get install -y tmux
 
 # install ros apt deps
 RUN apt-get install -y ros-noetic-tf ros-noetic-angles
@@ -37,4 +40,10 @@ RUN echo -e "source /opt/ros/noetic/setup.bash\n" \
 
 # build deps
 RUN source ~/.profile && cd amrl_msgs && make -j
-RUN source ~/.profile && cd ut_automata && make -j
+RUN source ~/.profile && cd ut_automata && make 
+
+# add launcher
+COPY --chown=dev:dev ./tmux_session.sh /home/dev/tmux_session.sh
+RUN chmod u+x /home/dev/tmux_session.sh
+CMD [ "/home/dev/tmux_session.sh" ]
+ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,7 @@ RUN apt-get update && \
     apt-get install -y git libgflags-dev libpopt-dev \
                        libgoogle-glog-dev liblua5.1-0-dev \
                        libboost-all-dev libqt5websockets5-dev \
-                       python-is-python3 libeigen3-dev sudo 
-
-# multiplexers to run roscore and other infra in background
-RUN apt-get install -y tmux
+                       python-is-python3 libeigen3-dev sudo tmux
 
 # install ros apt deps
 RUN apt-get install -y ros-noetic-tf ros-noetic-angles
@@ -47,4 +44,4 @@ ENV CS378_DOCKER_CONTEXT 1
 COPY --chown=dev:dev ./tmux_session.sh /home/dev/tmux_session.sh
 RUN chmod u+x /home/dev/tmux_session.sh
 CMD [ "/home/dev/tmux_session.sh" ]
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: build/CMakeLists.txt.copy
 	$(MAKE) --no-print-directory -C build
 
 docker_all: docker_build_q
-	docker run --rm --volume "$(shell pwd)":/home/dev/cs378_starter cs378_starter bash -lc "cd cs378_starter && make -j"
+	docker run --rm --volume "$(shell pwd)":/home/dev/cs378_starter cs378_starter "cd cs378_starter && make -j"
 
 docker_shell: docker_build_q
 	if [ $(shell docker ps -a -f name=cs378_starter_shell | wc -l) -ne 2 ]; then docker run -dit --name cs378_starter_shell --volume "$(shell pwd)":/home/dev/cs378_starter --workdir /home/dev/cs378_starter -p 10272:10272 cs378_starter; fi

--- a/README.md
+++ b/README.md
@@ -23,4 +23,8 @@ Please follow the instructions in the UT AUTOmata [reference manual](https://dri
 ### Optional: Building/Running with Docker
 1. Make sure you have Docker installed and set up.
 2. Make sure you are in the root directory of the repository.
-3. Run `make docker_all` to just compile. You can run `make docker_shell` to get a shell within the Docker container. Inside this shell, you can build with `make -j`, as well as run other utilities such as `roscore` and the `ut_automata` websocket and simulator.
+3. Run `make docker_all` to just compile. 
+4. You can run `make docker_shell` to get a shell within the Docker container. The shell will automatically launch `roscore` and the `ut_automata` websocket and simulator inside of a `tmux` session. Inside the shell, you can compile and run your navigation code and connect using localhost in the web visualization. 
+
+For debugging purposes, you can look at the tmux processes at any time by attaching to the session: `tmux a -t ROS`. For more information about `tmux`, refer to the [tmux documentation](https://tmuxguide.readthedocs.io/en/latest/tmux/tmux.html)
+5. To shutdown the docker container, run `make docker_stop`

--- a/tmux_session.sh
+++ b/tmux_session.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 
+tmux -V > /dev/null 2>&1
+if [ $? -eq 127 ]
+then
+    echo "tmux is not installed! Cannot continue"
+    exit 127
+fi
+
 session="ROS"
+
+INSTALL_PATH=$1
+if [ $INSTALL_PATH -eq ""]
+then
+    INSTALL_PATH="${HOME}/"
+fi
 
 tmux new-session -d -s $session 
 tmux set mouse on
@@ -11,10 +24,10 @@ tmux send-keys -t $session:$window 'roscore' C-m
 
 window=1
 tmux new-window -t $session:$window -n 'simulator'
-tmux send-keys -t $session:$window 'cd ~/ut_automata && ./bin/simulator --localize' C-m
+tmux send-keys -t $session:$window "cd ${INSTALL_PATH}/ut_automata && ./bin/simulator --localize" C-m
 
 window=2
 tmux new-window -t $session:$window -n 'websocket'
-tmux send-keys -t $session:$window 'cd ~/ut_automata && ./bin/websocket' C-m
+tmux send-keys -t $session:$window "cd ${INSTALL_PATH}/ut_automata && ./bin/websocket" C-m
 
 /bin/bash

--- a/tmux_session.sh
+++ b/tmux_session.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+session="ROS"
+
+tmux new-session -d -s $session 
+tmux set mouse on
+window=0
+
+tmux rename-window -t $session:$window 'roscore'
+tmux send-keys -t $session:$window 'roscore' C-m
+
+window=1
+tmux new-window -t $session:$window -n 'simulator'
+tmux send-keys -t $session:$window 'cd ~/ut_automata && ./bin/simulator --localize' C-m
+
+window=2
+tmux new-window -t $session:$window -n 'websocket'
+tmux send-keys -t $session:$window 'cd ~/ut_automata && ./bin/websocket' C-m
+
+/bin/bash

--- a/tmux_session.sh
+++ b/tmux_session.sh
@@ -9,21 +9,50 @@ fi
 
 session="ROS"
 
-INSTALL_PATH=$1
-if [ -z "${INSTALL_PATH}" ]
+tmux has-session -t $session > /dev/null 2>&1
+RUNNING=$?
+
+ARG=$1
+if [[ "${ARG}" == "stop" ]]
 then
-    INSTALL_PATH="${HOME}/"
+    if [ $RUNNING -ne 0 ]
+    then
+        echo "tmux session is not running."
+        exit 0
+    fi
+    
+    echo "Killing running tmux session"
+    tmux kill-session -t $session > /dev/null 2>&1
+    exit 0
 fi
 
-# check for /  at the end
-if [ ${INSTALL_PATH: -1} != '/' ]
+if [ $RUNNING -eq 0 ]
 then
-    INSTALL_PATH="${INSTALL_PATH}/"
+    echo "ERROR: tmux session is already running. Kill current session with ./tmux_session.sh stop"
+    exit 127
+fi
+
+
+if [ "${ARG}" == "-d" ]
+then
+    INSTALL_PATH=$2
+    if [ -z "${INSTALL_PATH}" ]
+    then
+        INSTALL_PATH="${HOME}/"
+    fi
+
+    # check for /  at the end
+    if [ ${INSTALL_PATH: -1} != '/' ]
+    then
+        INSTALL_PATH="${INSTALL_PATH}/"
+    fi
+else
+    INSTALL_PATH="${HOME}/"
 fi
 
 if ! [[ -d "${INSTALL_PATH}ut_automata" ]]
 then
-    echo "${INSTALL_PATH}ut_automata does not exist, please provide a valid path"
+    echo "${INSTALL_PATH}ut_automata does not exist, please provide a valid path using ./tmux_session.sh -d <INSTALL_PATH>"
     exit 127
 fi
 

--- a/tmux_session.sh
+++ b/tmux_session.sh
@@ -42,4 +42,7 @@ window=2
 tmux new-window -t $session:$window -n 'websocket'
 tmux send-keys -t $session:$window "cd ${INSTALL_PATH}/ut_automata && ./bin/websocket" C-m
 
-/bin/bash
+if ! [ -z ${CS378_DOCKER_CONTEXT+x} ]
+then
+    /bin/bash
+fi

--- a/tmux_session.sh
+++ b/tmux_session.sh
@@ -10,9 +10,21 @@ fi
 session="ROS"
 
 INSTALL_PATH=$1
-if [ $INSTALL_PATH -eq ""]
+if [ -z "${INSTALL_PATH}" ]
 then
     INSTALL_PATH="${HOME}/"
+fi
+
+# check for /  at the end
+if [ ${INSTALL_PATH: -1} != '/' ]
+then
+    INSTALL_PATH="${INSTALL_PATH}/"
+fi
+
+if ! [[ -d "${INSTALL_PATH}ut_automata" ]]
+then
+    echo "${INSTALL_PATH}ut_automata does not exist, please provide a valid path"
+    exit 127
 fi
 
 tmux new-session -d -s $session 


### PR DESCRIPTION
This PR adds some quality of life improvements to the Dockerfile recently added to the repo.

First, the `-j` flag on the make command for `ut_automata` would fail when building on macOS. While this may be limited to my machine, the time savings is minimal from adding the flag and was removed.

Second, this installs `tmux` in the container and introduces a simple launcher script that will create a tmux session with the entire infrastructure stack running. Students should only have to run `make docker_shell` to enter into the docker container. From there, `roscore`, `simulator`, and `websocket` are already running in a detached tmux session.